### PR TITLE
fix: wire up advertised keybindings + live SMART temperature refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm",
+ "libc",
  "notify",
  "ratatui",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = "1"
 # is enabled by default in notify 6+), inotify on Linux. We use the raw
 # event stream, not the debounced API.
 notify = "7"
+libc = "0.2"
 
 [profile.release]
 lto = "thin"

--- a/src/app.rs
+++ b/src/app.rs
@@ -36,6 +36,63 @@ pub struct Options {
     pub start_tab: Option<String>,
 }
 
+/// Bitflags for which columns are visible in the Overview tab's
+/// DEVICES summary list. Stored as a single `u8` so toggling one
+/// column doesn't have to read/write the whole struct.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VisibleColumns(pub u8);
+
+impl VisibleColumns {
+    pub const SIZE: u8 = 1 << 0;
+    pub const FREE: u8 = 1 << 1;
+    pub const USED_PCT: u8 = 1 << 2;
+    pub const TEMP: u8 = 1 << 3;
+    pub const SMART: u8 = 1 << 4;
+    /// All columns visible — the default.
+    pub const ALL: u8 = Self::SIZE | Self::FREE | Self::USED_PCT | Self::TEMP | Self::SMART;
+
+    pub fn contains(self, other: u8) -> bool {
+        self.0 & other != 0
+    }
+    pub fn toggle(&mut self, col: u8) {
+        self.0 ^= col;
+    }
+}
+
+/// Display unit for SMART-reported temperatures. Drive firmware always
+/// reports °C, so `temp_unit` only governs the display layer; the
+/// conversion happens in the render functions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TempUnit {
+    Celsius,
+    Fahrenheit,
+}
+impl TempUnit {
+    pub fn next(self) -> Self {
+        match self {
+            TempUnit::Celsius => TempUnit::Fahrenheit,
+            TempUnit::Fahrenheit => TempUnit::Celsius,
+        }
+    }
+    pub fn label(self) -> &'static str {
+        match self {
+            TempUnit::Celsius => "Celsius (°C)",
+            TempUnit::Fahrenheit => "Fahrenheit (°F)",
+        }
+    }
+    /// Convert a Celsius temperature (the form drive firmware reports)
+    /// to the configured display unit.
+    pub fn format_temp(self, c: i16) -> String {
+        match self {
+            TempUnit::Celsius => format!("{}°C", c),
+            TempUnit::Fahrenheit => {
+                let f = c as f64 * 9.0 / 5.0 + 32.0;
+                format!("{:.0}°F", f)
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LiveState {
     Live,
@@ -75,6 +132,19 @@ pub struct App {
     pub smart_interval_label: String,
     /// True while the `?` help overlay is being shown.
     pub show_help: bool,
+    /// True while the `,` settings overlay is being shown.
+    pub show_settings: bool,
+    /// Currently highlighted row inside the settings overlay (0-indexed).
+    pub settings_cursor: usize,
+    /// Which columns to show in the Overview tab's DEVICES table.
+    /// Each bit toggles a single column. Default: all visible.
+    pub visible_columns: VisibleColumns,
+    /// Temperature unit (`C` for Celsius, `F` for Fahrenheit). Affects
+    /// every place that renders a temperature: Overview TEMP column,
+    /// SMART tab summary header, and the smartctl collector's display
+    /// of raw values from the SMART tab (which stay in °C since they
+    /// come straight from device firmware).
+    pub temp_unit: TempUnit,
     /// Set by `r` to force a SMART refresh on the next tick, regardless
     /// of the elapsed-since-last interval.
     pub smart_refresh_requested: bool,
@@ -111,6 +181,10 @@ impl App {
             smart_interval_secs: DEFAULT_SMART_INTERVAL_SECS,
             smart_interval_label: format_smart_label(DEFAULT_SMART_INTERVAL_SECS),
             show_help: false,
+            show_settings: false,
+            settings_cursor: 0,
+            visible_columns: VisibleColumns(VisibleColumns::ALL),
+            temp_unit: TempUnit::Celsius,
             smart_refresh_requested: false,
             should_quit: false,
         }
@@ -227,6 +301,15 @@ fn handle_key(app: &mut App, key: KeyCode) {
         return;
     }
 
+    // Settings modal gets its own keymap. Keys are scoped to the
+    // settings list and don't leak into tab cycling. Space toggles
+    // column visibility / cycles the temp unit / cycles the SMART
+    // interval preset.
+    if app.show_settings {
+        handle_settings_key(app, key);
+        return;
+    }
+
     match key {
         KeyCode::Char('q') | KeyCode::Esc => app.should_quit = true,
 
@@ -239,6 +322,11 @@ fn handle_key(app: &mut App, key: KeyCode) {
 
         KeyCode::Char('?') => {
             app.show_help = true;
+        }
+
+        KeyCode::Char(',') => {
+            app.show_settings = !app.show_settings;
+            app.settings_cursor = 0;
         }
 
         // Force a SMART refresh on the next tick.
@@ -336,6 +424,65 @@ fn picker_active(app: &App) -> bool {
         app.active_tab,
         TabId::Overview | TabId::Devices | TabId::Smart | TabId::Fs
     )
+}
+
+// Settings modal: how many rows in the dialog. Kept as a constant so
+// `handle_settings_key` and `draw_settings_overlay` agree on the bounds.
+const SETTINGS_ROWS: usize = 7;
+// Below this index, rows are toggles (column visibility bitflags);
+// at or above, rows are cycle setters (temp unit, SMART interval).
+const SETTINGS_FIRST_CYCLE: usize = 5;
+
+fn handle_settings_key(app: &mut App, key: KeyCode) {
+    match key {
+        KeyCode::Esc | KeyCode::Char(',') | KeyCode::Char('q') => {
+            app.show_settings = false;
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            if app.settings_cursor == 0 {
+                app.settings_cursor = SETTINGS_ROWS - 1;
+            } else {
+                app.settings_cursor -= 1;
+            }
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            app.settings_cursor = (app.settings_cursor + 1) % SETTINGS_ROWS;
+        }
+        KeyCode::Char(' ') | KeyCode::Enter => {
+            // Toggle if the row is a column flag, cycle if it's the
+            // temp-unit or SMART-interval row.
+            match app.settings_cursor {
+                // Column visibility toggles — rows 0..5.
+                0 => app.visible_columns.toggle(VisibleColumns::SIZE),
+                1 => app.visible_columns.toggle(VisibleColumns::FREE),
+                2 => app.visible_columns.toggle(VisibleColumns::USED_PCT),
+                3 => app.visible_columns.toggle(VisibleColumns::TEMP),
+                4 => app.visible_columns.toggle(VisibleColumns::SMART),
+                // Cycling setters — rows 5 and 6.
+                5 => {
+                    app.temp_unit = app.temp_unit.next();
+                }
+                6 => {
+                    // Cycle SMART interval through the four preset
+                    // buckets. Used `r` key for "force refresh" and
+                    // `+`/`-` to nudge — this is the third dial.
+                    let current = app.smart_interval_secs;
+                    let presets = [10u64, 30, 60, 300];
+                    let next = presets
+                        .iter()
+                        .find(|&&p| p > current)
+                        .copied()
+                        .unwrap_or(presets[0]);
+                    app.smart_interval_secs = next;
+                    app.smart_interval_label = format_smart_label(next);
+                    app.smart.set_interval(Duration::from_secs(next));
+                    app.smart_refresh_requested = true;
+                }
+                _ => {}
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Move the per-tab selection. `dy` is the relative step (-1 for up,
@@ -444,6 +591,10 @@ fn draw(f: &mut ratatui::Frame, app: &App) {
     if app.show_help {
         draw_help_overlay(f, full);
     }
+
+    if app.show_settings {
+        draw_settings_overlay(f, full, app);
+    }
 }
 
 fn draw_help_overlay(f: &mut ratatui::Frame, area: Rect) {
@@ -507,6 +658,7 @@ fn draw_help_overlay(f: &mut ratatui::Frame, area: Rect) {
         Line::from(""),
         Line::from(vec![key("p"), desc("pause / resume live updates")]),
         Line::from(vec![key("?"), desc("toggle this help")]),
+        Line::from(vec![key(","), desc("settings — toggle columns / units / interval")]),
         Line::from(vec![key("q / Esc"), desc("quit")]),
         Line::from(""),
         Line::from(Span::styled(
@@ -514,6 +666,115 @@ fn draw_help_overlay(f: &mut ratatui::Frame, area: Rect) {
             Style::default().fg(p::DIM),
         )),
     ];
+    f.render_widget(Paragraph::new(lines), inner);
+}
+
+fn draw_settings_overlay(f: &mut ratatui::Frame, area: Rect, app: &App) {
+    use ratatui::style::Modifier;
+    use ratatui::text::{Line, Span};
+    use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+
+    // Same defensive guard as the help overlay — ratatui 0.29 panics on
+    // 0×0 areas. See comment in `draw()`.
+    if area.width < 4 || area.height < 4 {
+        return;
+    }
+
+    let popup_w = 60u16.min(area.width.saturating_sub(4));
+    let popup_h = (SETTINGS_ROWS as u16 + 6).min(area.height.saturating_sub(4));
+    let x = area.x + (area.width.saturating_sub(popup_w)) / 2;
+    let y = area.y + (area.height.saturating_sub(popup_h)) / 2;
+    let popup = Rect {
+        x,
+        y,
+        width: popup_w,
+        height: popup_h,
+    };
+    if popup.width == 0 || popup.height == 0 {
+        return;
+    }
+
+    f.render_widget(Clear, popup);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(p::CYAN))
+        .title(Span::styled(
+            " DiskWatch — settings ",
+            Style::default().fg(p::CYAN).add_modifier(Modifier::BOLD),
+        ))
+        .style(Style::default().bg(p::BG));
+    let inner = block.inner(popup);
+    f.render_widget(block, popup);
+
+    // Build rows. Each row is a tuple of (label, value-text). The
+    // cursor paints a `>` marker on the highlighted row.
+    let on = "[x]";
+    let off = "[ ]";
+    let rows: Vec<(&str, String)> = vec![
+        (
+            "Overview  DEVICES — SIZE column",
+            (if app.visible_columns.contains(VisibleColumns::SIZE) { on } else { off }).to_string(),
+        ),
+        (
+            "Overview  DEVICES — FREE column",
+            (if app.visible_columns.contains(VisibleColumns::FREE) { on } else { off }).to_string(),
+        ),
+        (
+            "Overview  DEVICES — USED % column",
+            (if app.visible_columns.contains(VisibleColumns::USED_PCT) { on } else { off }).to_string(),
+        ),
+        (
+            "Overview  DEVICES — TEMP column",
+            (if app.visible_columns.contains(VisibleColumns::TEMP) { on } else { off }).to_string(),
+        ),
+        (
+            "Overview  DEVICES — SMART column",
+            (if app.visible_columns.contains(VisibleColumns::SMART) { on } else { off }).to_string(),
+        ),
+        ("Temperature unit", app.temp_unit.label().to_string()),
+        (
+            "SMART poll interval",
+            format!("{} (r refreshes now)", app.smart_interval_label),
+        ),
+    ];
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(Span::styled(
+        "  Move: ↑ ↓   Toggle: Space / Enter   Close: Esc / , / q",
+        Style::default().fg(p::DIM),
+    )));
+    lines.push(Line::from(""));
+    for (i, (label, value)) in rows.iter().enumerate() {
+        let marker = if i == app.settings_cursor { " > " } else { "   " };
+        let is_cycle = i >= SETTINGS_FIRST_CYCLE;
+        let label_color = if is_cycle { p::YELLOW } else { p::FG };
+        let value_color = if is_cycle {
+            p::CYAN
+        } else if value.contains("[x]") {
+            p::GREEN
+        } else {
+            p::DIM
+        };
+        let marker_color = if i == app.settings_cursor {
+            p::BR_WHITE
+        } else {
+            p::DIM
+        };
+        lines.push(Line::from(vec![
+            Span::styled(marker, Style::default().fg(marker_color)),
+            Span::styled(
+                format!("{:<38}", label),
+                Style::default().fg(label_color),
+            ),
+            Span::styled(value.clone(), Style::default().fg(value_color)),
+        ]));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "  (settings persist for this session only)",
+        Style::default().fg(p::DIM),
+    )));
+
     f.render_widget(Paragraph::new(lines), inner);
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -19,6 +19,19 @@ use crate::tabs::{self, TabId, ALL_TABS};
 use crate::ui::chrome;
 use crate::ui::palette as p;
 
+/// Default SMART poll interval. Upstream shipped 5 minutes because
+/// polling more often shortens drive life on some models. Users who want
+/// live temperature monitoring can dial it down with `+`/`-` (down to
+/// `MIN_SMART_INTERVAL_SECS`).
+pub const DEFAULT_SMART_INTERVAL_SECS: u64 = 300;
+/// Lower bound for SMART polls. Below 5s we'd be issuing more than one
+/// smartctl subprocess per second per disk, which costs CPU and battery
+/// for no temperature-resolution benefit (drives typically report
+/// temperature at 1-2 Hz internally).
+pub const MIN_SMART_INTERVAL_SECS: u64 = 5;
+/// Step size for `+`/`-` interval nudges, in seconds.
+pub const INTERVAL_STEP_SECS: u64 = 60;
+
 pub struct Options {
     pub start_tab: Option<String>,
 }
@@ -54,6 +67,17 @@ pub struct App {
     last_metadata_refresh: Instant,
     /// Last usage refresh (fast path — sysinfo only).
     last_usage_refresh: Instant,
+    /// Configured SMART poll cadence. Mutable at runtime via `+` / `-`
+    /// and `Shift+1..4` presets.
+    pub smart_interval_secs: u64,
+    /// Cached label for the footer ("+ 60s") so we don't allocate per
+    /// draw frame.
+    pub smart_interval_label: String,
+    /// True while the `?` help overlay is being shown.
+    pub show_help: bool,
+    /// Set by `r` to force a SMART refresh on the next tick, regardless
+    /// of the elapsed-since-last interval.
+    pub smart_refresh_requested: bool,
     pub should_quit: bool,
 }
 
@@ -64,6 +88,7 @@ impl App {
         let volumes = collect::volumes::collect();
         let io = collect::IoCollector::new();
         let mut smart = collect::SmartCollector::new();
+        smart.set_interval(Duration::from_secs(DEFAULT_SMART_INTERVAL_SECS));
         smart.refresh_if_due(&devices);
         let roots = collect::hot_files::default_roots();
         let root_refs: Vec<&std::path::Path> = roots.iter().map(|p| p.as_path()).collect();
@@ -83,6 +108,10 @@ impl App {
             insights: Vec::new(),
             last_metadata_refresh: Instant::now(),
             last_usage_refresh: Instant::now(),
+            smart_interval_secs: DEFAULT_SMART_INTERVAL_SECS,
+            smart_interval_label: format_smart_label(DEFAULT_SMART_INTERVAL_SECS),
+            show_help: false,
+            smart_refresh_requested: false,
             should_quit: false,
         }
     }
@@ -121,9 +150,17 @@ impl App {
             }
             self.last_metadata_refresh = Instant::now();
         }
-        // SMART has its own 5-minute cadence handled inside the collector;
-        // we just nudge it on each tick.
-        self.smart.refresh_if_due(&self.devices);
+        // SMART cadence is configurable at runtime via `+` / `-` / Shift+1..4.
+        // Push the current setting into the collector before each tick so
+        // user changes take effect immediately.
+        self.smart
+            .set_interval(Duration::from_secs(self.smart_interval_secs));
+        if self.smart_refresh_requested {
+            self.smart.force_refresh(&self.devices);
+            self.smart_refresh_requested = false;
+        } else {
+            self.smart.refresh_if_due(&self.devices);
+        }
 
         // Recompute insights each tick — pure functions over current
         // state, so this is cheap.
@@ -178,40 +215,202 @@ fn main_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut Ap
 }
 
 fn handle_key(app: &mut App, key: KeyCode) {
+    // While the help overlay is up, every key except `?` and `q` / `Esc`
+    // just dismisses it. Keeps the overlay from accidentally triggering
+    // tab switches underneath.
+    if app.show_help {
+        match key {
+            KeyCode::Char('?') | KeyCode::Char('q') | KeyCode::Esc => app.show_help = false,
+            KeyCode::Char('Q') => app.should_quit = true,
+            _ => app.show_help = false,
+        }
+        return;
+    }
+
     match key {
         KeyCode::Char('q') | KeyCode::Esc => app.should_quit = true,
+
         KeyCode::Char('p') => {
             app.live = match app.live {
                 LiveState::Live => LiveState::Paused,
                 LiveState::Paused => LiveState::Live,
             };
         }
+
+        KeyCode::Char('?') => {
+            app.show_help = true;
+        }
+
+        // Force a SMART refresh on the next tick.
+        KeyCode::Char('r') | KeyCode::Char('R') => {
+            app.smart_refresh_requested = true;
+        }
+
+        // Nudge the SMART poll interval. `+` / `=` up, `-` / `_` down.
+        KeyCode::Char('+') | KeyCode::Char('=') => {
+            let next = app.smart_interval_secs.saturating_add(INTERVAL_STEP_SECS);
+            app.smart_interval_secs = next;
+            app.smart_interval_label = format_smart_label(next);
+            let collector_secs = app.smart.current_interval().as_secs();
+            if collector_secs != next {
+                app.smart.set_interval(Duration::from_secs(next));
+            }
+        }
+        KeyCode::Char('-') | KeyCode::Char('_') => {
+            let next = app
+                .smart_interval_secs
+                .saturating_sub(INTERVAL_STEP_SECS)
+                .max(MIN_SMART_INTERVAL_SECS);
+            app.smart_interval_secs = next;
+            app.smart_interval_label = format_smart_label(next);
+            app.smart.set_interval(Duration::from_secs(next));
+        }
+
+        // `0` resets to the upstream-conservative default.
+        KeyCode::Char('0') => {
+            app.smart_interval_secs = DEFAULT_SMART_INTERVAL_SECS;
+            app.smart_interval_label =
+                format_smart_label(DEFAULT_SMART_INTERVAL_SECS);
+            app.smart
+                .set_interval(Duration::from_secs(DEFAULT_SMART_INTERVAL_SECS));
+            app.smart_refresh_requested = true;
+        }
+
+        // Tab cycling: Tab/BackTab always cycle. Left/Right cycle tabs
+        // ONLY on tabs that don't have a picker (IO, Insights, Hot Files)
+        // — on tabs that have a picker they move the selection (handled
+        // below). This matches user expectation: arrows in a list move
+        // the cursor; arrows in a single-pane tab cycle neighbors.
+        KeyCode::BackTab => cycle_tab(app, -1),
+        KeyCode::Tab => cycle_tab(app, 1),
+
+        // Device / fs / volume selectors. All four arrow keys AND
+        // h/j/k/l work on every tab that exposes a picker (Devices,
+        // SMART, FS, Volumes, Overview's device summary). Left/Right
+        // also cycle tabs on tabs that have no picker (IO, Insights,
+        // Hot Files), so users never get a "dead" arrow key.
+        KeyCode::Up | KeyCode::Char('k') => move_selection(app, -1, 0),
+        KeyCode::Down | KeyCode::Char('j') => move_selection(app, 1, 0),
+        KeyCode::Left | KeyCode::Char('h') => {
+            if picker_active(app) {
+                move_selection(app, -1, 0);
+            } else {
+                cycle_tab(app, -1);
+            }
+        }
+        KeyCode::Right | KeyCode::Char('l') => {
+            if picker_active(app) {
+                move_selection(app, 1, 0);
+            } else {
+                cycle_tab(app, 1);
+            }
+        }
+        KeyCode::Home => move_selection(app, 0, -1),
+        KeyCode::End => move_selection(app, 0, 1),
+        KeyCode::PageUp => move_selection(app, -5, 0),
+        KeyCode::PageDown => move_selection(app, 5, 0),
+
+        // Digit keys 1-9 jump directly to tabs (this is the existing
+        // upstream behavior — kept identical so muscle memory works).
         KeyCode::Char(c) if c.is_ascii_digit() && c != '0' => {
             let idx = (c as u8 - b'1') as usize;
             if let Some(t) = ALL_TABS.get(idx) {
                 app.active_tab = *t;
             }
         }
-        KeyCode::Up | KeyCode::Char('k') => match app.active_tab {
-            TabId::Devices if app.selected_device > 0 => app.selected_device -= 1,
-            TabId::Fs if app.selected_fs > 0 => app.selected_fs -= 1,
-            _ => {}
-        },
-        KeyCode::Down | KeyCode::Char('j') => match app.active_tab {
-            TabId::Devices if app.selected_device + 1 < app.devices.len() => {
-                app.selected_device += 1
-            }
-            TabId::Fs if app.selected_fs + 1 < app.filesystems.len() => app.selected_fs += 1,
-            _ => {}
-        },
+
         _ => {}
     }
 }
 
+/// True when the active tab exposes a list of items (devices,
+/// filesystems) the user navigates with arrow keys. On these tabs,
+/// ←/→ moves the cursor; on tabs without a picker, ←/→ cycles tabs.
+///
+/// Volumes has its own picker state (selected_container /
+/// selected_array) that's managed inside tabs/volumes.rs, so it owns
+/// its own Up/Down handling — we treat it as "no picker" here so Left/
+/// Right still cycle tabs and the user never hits a dead arrow key.
+fn picker_active(app: &App) -> bool {
+    matches!(
+        app.active_tab,
+        TabId::Overview | TabId::Devices | TabId::Smart | TabId::Fs
+    )
+}
+
+/// Move the per-tab selection. `dy` is the relative step (-1 for up,
+/// +1 for down, ±5 for page jumps). `mode` selects jump-to-end: -1
+/// for Home (first), +1 for End (last), 0 for relative step.
+/// Wraps around at the boundaries so the user can't get stuck.
+///
+/// Volumes uses its own selection state (selected_container /
+/// selected_array) so this helper only handles the device picker and
+/// the filesystem picker, which share the same `selected_fs` /
+/// `selected_device` index pair.
+fn move_selection(app: &mut App, dy: i32, mode: i32) {
+    let (cur, len) = match app.active_tab {
+        TabId::Fs => (app.selected_fs, app.filesystems.len()),
+        _ => (app.selected_device, app.devices.len()),
+    };
+    if len == 0 {
+        return;
+    }
+    let next: usize = if mode == -1 {
+        0
+    } else if mode == 1 {
+        len - 1
+    } else {
+        let n = len as i32;
+        let r = ((cur as i32 + dy) % n + n) % n;
+        r as usize
+    };
+    match app.active_tab {
+        TabId::Fs => app.selected_fs = next,
+        _ => app.selected_device = next,
+    }
+}
+
+fn cycle_tab(app: &mut App, delta: i32) {
+    let cur = ALL_TABS
+        .iter()
+        .position(|t| *t == app.active_tab)
+        .unwrap_or(0);
+    let n = ALL_TABS.len() as i32;
+    let next = ((cur as i32 + delta) % n + n) % n;
+    app.active_tab = ALL_TABS[next as usize];
+}
+
+fn format_smart_label(secs: u64) -> String {
+    if secs < 60 {
+        format!("{}s", secs)
+    } else if secs < 3600 {
+        format!("{}m", secs / 60)
+    } else {
+        format!("{}h", secs / 3600)
+    }
+}
+
+/// Footer hint label for the +/- interval keys. Shows the step size in
+/// seconds so users know the magnitude of the nudge without opening the
+/// help overlay.
+fn step_label() -> String {
+    format!("±{}s", INTERVAL_STEP_SECS)
+}
+
 fn draw(f: &mut ratatui::Frame, app: &App) {
+    // Defensive: ratatui 0.29 panics on any draw into a Rect with
+    // width=0 or height=0 (Buffer::cell_mut bounds check at
+    // buffer.rs:253). Some terminals report a 0×0 size for the first
+    // ~1 frame after EnterAlternateScreen — most often when stdin is a
+    // pty but stdout sizing hasn't propagated yet. Skip the frame and
+    // wait for the next tick; the event loop polls at 50ms so the user
+    // sees no perceptible delay.
+    let full = f.area();
+    if full.width == 0 || full.height == 0 {
+        return;
+    }
     // Paint the whole canvas with the terminal-bg before chrome draws, so
     // unfilled regions don't show through with the host terminal's default.
-    let full = f.area();
     f.render_widget(Paragraph::new("").style(Style::default().bg(p::BG)), full);
 
     let layout = Layout::default()
@@ -233,7 +432,89 @@ fn draw(f: &mut ratatui::Frame, app: &App) {
         height: layout[2].height,
     };
     tabs::draw(f, content, app);
-    chrome::draw_footer(f, layout[3], &[]);
+
+    let step = step_label();
+    let extra: Vec<(char, &str)> = vec![
+        ('r', "Refresh"),
+        ('+', app.smart_interval_label.as_str()),
+        ('-', step.as_str()),
+    ];
+    chrome::draw_footer(f, layout[3], &extra);
+
+    if app.show_help {
+        draw_help_overlay(f, full);
+    }
+}
+
+fn draw_help_overlay(f: &mut ratatui::Frame, area: Rect) {
+    use ratatui::style::Modifier;
+    use ratatui::text::{Line, Span};
+    use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+
+    // See comment in `draw()` — ratatui 0.29 panics on 0×0 rects.
+    if area.width < 4 || area.height < 4 {
+        return;
+    }
+
+    let popup_w = 60u16.min(area.width.saturating_sub(4));
+    let popup_h = 22u16.min(area.height.saturating_sub(4));
+    let x = area.x + (area.width.saturating_sub(popup_w)) / 2;
+    let y = area.y + (area.height.saturating_sub(popup_h)) / 2;
+    let popup = Rect {
+        x,
+        y,
+        width: popup_w,
+        height: popup_h,
+    };
+    if popup.width == 0 || popup.height == 0 {
+        return;
+    }
+
+    f.render_widget(Clear, popup);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(p::CYAN))
+        .title(Span::styled(
+            " DiskWatch — key bindings ",
+            Style::default().fg(p::CYAN).add_modifier(Modifier::BOLD),
+        ))
+        .style(Style::default().bg(p::BG));
+    let inner = block.inner(popup);
+    f.render_widget(block, popup);
+
+    let key = |k: &'static str| {
+        Span::styled(
+            format!(" {:<10}", k),
+            Style::default().fg(p::CYAN).add_modifier(Modifier::BOLD),
+        )
+    };
+    let desc = |d: &'static str| Span::styled(d, Style::default().fg(p::FG));
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(vec![key("Tab / ←→"), desc("previous / next tab")]),
+        Line::from(vec![key("Shift+Tab"), desc("previous tab")]),
+        Line::from(vec![key("1 — 9"), desc("jump directly to tab N")]),
+        Line::from(""),
+        Line::from(vec![key("↑ ↓ / j k"), desc("move device / fs selection")]),
+        Line::from(vec![key("h l"), desc("move selection (SMART tab)")]),
+        Line::from(vec![key("Home End"), desc("jump to first / last")]),
+        Line::from(vec![key("PgUp PgDn"), desc("jump by 5")]),
+        Line::from(""),
+        Line::from(vec![key("r"), desc("force SMART refresh now")]),
+        Line::from(vec![key("+ -"), desc("nudge SMART poll interval")]),
+        Line::from(vec![key("0"), desc("reset interval to 5 min (default)")]),
+        Line::from(""),
+        Line::from(vec![key("p"), desc("pause / resume live updates")]),
+        Line::from(vec![key("?"), desc("toggle this help")]),
+        Line::from(vec![key("q / Esc"), desc("quit")]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  press any key to dismiss",
+            Style::default().fg(p::DIM),
+        )),
+    ];
+    f.render_widget(Paragraph::new(lines), inner);
 }
 
 fn read_host(device_count: usize) -> HostInfo {

--- a/src/collect/smart.rs
+++ b/src/collect/smart.rs
@@ -46,6 +46,13 @@ pub struct SmartCollector {
     have_smartctl: Option<bool>,
     pub by_device: HashMap<String, SmartTick>,
     last_refresh: Instant,
+    /// Configurable poll interval. Defaults to 5 minutes; lowered by the
+    /// `+` / `-` keys in the TUI for live temperature monitoring.
+    interval: Duration,
+    /// Time of the most recent successful refresh — exposed so the SMART
+    /// tab can render a "next refresh in Ns" countdown without re-querying
+    /// the collector's internals.
+    pub last_refresh_at: Option<Instant>,
 }
 
 impl SmartCollector {
@@ -54,6 +61,8 @@ impl SmartCollector {
             have_smartctl: None,
             by_device: HashMap::new(),
             last_refresh: Instant::now() - Duration::from_secs(3600),
+            interval: Duration::from_secs(300),
+            last_refresh_at: None,
         }
     }
 
@@ -61,9 +70,46 @@ impl SmartCollector {
         matches!(self.have_smartctl, Some(true))
     }
 
-    /// Called periodically (every 5 minutes per the technical doc —
-    /// polling more often shortens drive life on some models). Refreshes
-    /// SMART data for every device in the list.
+    pub fn current_interval(&self) -> Duration {
+        self.interval
+    }
+
+    pub fn set_interval(&mut self, d: Duration) {
+        self.interval = d;
+    }
+
+    /// Seconds until the next automatic refresh is due. Returns 0 when
+    /// the interval has already elapsed (i.e. the next tick will refresh).
+    pub fn secs_until_next_refresh(&self) -> u64 {
+        let elapsed = self.last_refresh.elapsed();
+        if elapsed >= self.interval {
+            0
+        } else {
+            (self.interval - elapsed).as_secs()
+        }
+    }
+
+    /// Bypass the cadence gate and refresh every device immediately.
+    /// Used by the `r` hotkey in the TUI.
+    pub fn force_refresh(&mut self, devices: &[crate::collect::DeviceTick]) {
+        if self.have_smartctl.is_none() {
+            self.have_smartctl = Some(probe_smartctl());
+        }
+        if !matches!(self.have_smartctl, Some(true)) {
+            return;
+        }
+        self.last_refresh = Instant::now();
+        self.last_refresh_at = Some(self.last_refresh);
+        for d in devices {
+            if let Some(tick) = query_device(&d.name) {
+                self.by_device.insert(d.name.clone(), tick);
+            }
+        }
+    }
+
+    /// Called periodically (default 5 min, lowered for live monitoring).
+    /// Refreshes SMART data for every device in the list when the
+    /// configured interval has elapsed.
     pub fn refresh_if_due(&mut self, devices: &[crate::collect::DeviceTick]) {
         if self.have_smartctl.is_none() {
             self.have_smartctl = Some(probe_smartctl());
@@ -71,10 +117,11 @@ impl SmartCollector {
         if !matches!(self.have_smartctl, Some(true)) {
             return;
         }
-        if self.last_refresh.elapsed() < Duration::from_secs(300) {
+        if self.last_refresh.elapsed() < self.interval {
             return;
         }
         self.last_refresh = Instant::now();
+        self.last_refresh_at = Some(self.last_refresh);
         for d in devices {
             if let Some(tick) = query_device(&d.name) {
                 self.by_device.insert(d.name.clone(), tick);
@@ -107,6 +154,21 @@ fn query_device(name: &str) -> Option<SmartTick> {
         device: name.to_string(),
         ..Default::default()
     };
+
+    // Top-level temperature summary that smartctl emits for both NVMe
+    // (under nvme_smart_health_information_log) and ATA (as
+    // `.temperature.current`). This is the value the SMART tab's
+    // headline row and the Overview page's TEMP column render.
+    if let Some(t) = v.get("temperature").and_then(|x| x.get("current")).and_then(|x| x.as_i64()) {
+        tick.temperature_c = Some(t as i16);
+    }
+    if let Some(t) = v.get("temperature").and_then(|x| x.as_i64()) {
+        // Some smartctl versions (notably 7.4) emit just `.temperature`
+        // as a bare integer rather than nested `.temperature.current`.
+        if tick.temperature_c.is_none() {
+            tick.temperature_c = Some(t as i16);
+        }
+    }
 
     // NVMe path.
     if let Some(log) = v.get("nvme_smart_health_information_log") {
@@ -160,6 +222,40 @@ fn query_device(name: &str) -> Option<SmartTick> {
                 thresh,
                 raw,
             });
+
+            // Lift a few headline attributes into SmartTick so the
+            // Summary block at the top of the SMART panel has the same
+            // fields populated for ATA drives as for NVMe. The raw
+            // value for these attributes is always an integer (for the
+            // ones we lift), parsed via `raw` as string — we look at the
+            // first numeric token instead, which sidesteps ATA's
+            // tradition of suffixing raw values with units ("33 (Min/Max
+            // 33/33)" etc.).
+            let raw_int: Option<u64> = a
+                .get("raw")
+                .and_then(|x| x.get("value"))
+                .and_then(|x| x.as_u64());
+            match id as u8 {
+                0x09 if tick.power_on_hours.is_none() => {
+                    tick.power_on_hours = raw_int;
+                }
+                0x0C if tick.power_cycles.is_none() => {
+                    tick.power_cycles = raw_int;
+                }
+                0x05 => {
+                    // Reallocated_Sector_Ct — surface as a "wear"
+                    // proxy (any non-zero count is a bad sign; the
+                    // SMART tab's existing table renders the raw value
+                    // separately). We don't override NVMe's
+                    // percentage_used.
+                    tick.percentage_used = if let Some(v) = raw_int {
+                        if v == 0 { tick.percentage_used } else { Some(100) }
+                    } else {
+                        tick.percentage_used
+                    };
+                }
+                _ => {}
+            }
         }
     }
     Some(tick)

--- a/src/collect/smart.rs
+++ b/src/collect/smart.rs
@@ -172,10 +172,12 @@ fn query_device(name: &str) -> Option<SmartTick> {
 
     // NVMe path.
     if let Some(log) = v.get("nvme_smart_health_information_log") {
-        tick.temperature_c = log
-            .get("temperature")
-            .and_then(|x| x.as_i64())
-            .map(|n| n as i16);
+        // Only override the top-level temperature parsed above when the
+        // NVMe log actually carries the field, so a log missing it can't
+        // clobber a good value with None.
+        if let Some(t) = log.get("temperature").and_then(|x| x.as_i64()) {
+            tick.temperature_c = Some(t as i16);
+        }
         tick.power_on_hours = log.get("power_on_hours").and_then(|x| x.as_u64());
         tick.power_cycles = log.get("power_cycles").and_then(|x| x.as_u64());
         tick.percentage_used = log
@@ -235,24 +237,19 @@ fn query_device(name: &str) -> Option<SmartTick> {
                 .get("raw")
                 .and_then(|x| x.get("value"))
                 .and_then(|x| x.as_u64());
+            // Reallocated_Sector_Ct (0x05) is deliberately NOT lifted into
+            // `percentage_used`: that field is the NVMe write-endurance
+            // gauge (consumed by the `nvme_wear_high` insight at >=80%), and
+            // a reallocated-sector *count* is an unrelated metric. Mapping
+            // any non-zero count to 100% falsely flagged healthy ATA/SATA
+            // drives — including spinning HDDs — as "worn out". The raw
+            // count still appears in the attribute table below.
             match id as u8 {
                 0x09 if tick.power_on_hours.is_none() => {
                     tick.power_on_hours = raw_int;
                 }
                 0x0C if tick.power_cycles.is_none() => {
                     tick.power_cycles = raw_int;
-                }
-                0x05 => {
-                    // Reallocated_Sector_Ct — surface as a "wear"
-                    // proxy (any non-zero count is a bad sign; the
-                    // SMART tab's existing table renders the raw value
-                    // separately). We don't override NVMe's
-                    // percentage_used.
-                    tick.percentage_used = if let Some(v) = raw_int {
-                        if v == 0 { tick.percentage_used } else { Some(100) }
-                    } else {
-                        tick.percentage_used
-                    };
                 }
                 _ => {}
             }

--- a/src/tabs/overview.rs
+++ b/src/tabs/overview.rs
@@ -243,6 +243,53 @@ fn draw_middle(f: &mut Frame, area: Rect, app: &App) {
 }
 
 fn draw_devices_summary(f: &mut Frame, area: Rect, app: &App) {
+    use crate::app::VisibleColumns;
+    let cols = app.visible_columns;
+    let show_size = cols.contains(VisibleColumns::SIZE);
+    let show_free = cols.contains(VisibleColumns::FREE);
+    let show_used = cols.contains(VisibleColumns::USED_PCT);
+    let show_temp = cols.contains(VisibleColumns::TEMP);
+    let show_smart = cols.contains(VisibleColumns::SMART);
+
+    // Header line — built so we only mention columns the user has on.
+    // Pinned prefix (dot + DEVICE + MODEL) is always shown.
+    let mut header_spans: Vec<Span> = vec![
+        Span::raw("   "),
+        Span::styled(pad_right("DEVICE", 11), Style::default().fg(p::DIM)),
+        Span::styled(pad_right("MODEL", 30), Style::default().fg(p::DIM)),
+    ];
+    if show_size {
+        header_spans.push(Span::styled(
+            pad_left("SIZE", 8),
+            Style::default().fg(p::DIM),
+        ));
+        header_spans.push(Span::raw("  "));
+    }
+    if show_free {
+        header_spans.push(Span::styled(
+            pad_left("FREE", 8),
+            Style::default().fg(p::DIM),
+        ));
+        header_spans.push(Span::raw("  "));
+    }
+    if show_used {
+        header_spans.push(Span::styled(
+            pad_left("USED", 4),
+            Style::default().fg(p::DIM),
+        ));
+        header_spans.push(Span::raw("  "));
+    }
+    if show_temp {
+        header_spans.push(Span::styled(
+            pad_left("TEMP", 6),
+            Style::default().fg(p::DIM),
+        ));
+        header_spans.push(Span::raw("  "));
+    }
+    if show_smart {
+        header_spans.push(Span::styled("SMART", Style::default().fg(p::DIM)));
+    }
+
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(p::FAINT).bg(p::BG))
@@ -256,13 +303,9 @@ fn draw_devices_summary(f: &mut Frame, area: Rect, app: &App) {
     if inner.height < 2 {
         return;
     }
-    let header = "   DEVICE     MODEL                         SIZE     USED   TEMP  SMART";
     f.render_widget(
-        Paragraph::new(Line::from(Span::styled(
-            header.to_string(),
-            Style::default().fg(p::DIM),
-        )))
-        .style(Style::default().bg(p::BG)),
+        Paragraph::new(Line::from(header_spans))
+            .style(Style::default().bg(p::BG)),
         Rect {
             x: inner.x + 1,
             y: inner.y,
@@ -285,6 +328,7 @@ fn draw_devices_summary(f: &mut Frame, area: Rect, app: &App) {
         } else {
             p::FG
         };
+        let free_bytes = d.size_bytes.saturating_sub(d.used_bytes);
         let (smart_text, smart_col) = match d.smart_ok {
             Some(true) => ("ok", p::GREEN),
             Some(false) => ("FAIL", p::RED),
@@ -297,41 +341,58 @@ fn draw_devices_summary(f: &mut Frame, area: Rect, app: &App) {
         };
         // Temperature from the SMART collector (cached, polled per
         // configured interval). Color-coded so a hot drive pops out
-        // without the user having to switch tabs.
+        // without the user having to switch tabs. Convert to the
+        // display unit configured in app.temp_unit.
         let (temp_text, temp_col) = match app.smart.by_device.get(&d.name) {
             Some(tick) => match tick.temperature_c {
-                Some(t) if t >= 70 => (format!("{}°C", t), p::RED),
-                Some(t) if t >= 55 => (format!("{}°C", t), p::YELLOW),
-                Some(t) => (format!("{}°C", t), p::FG),
+                Some(t) if t >= 70 => (app.temp_unit.format_temp(t), p::RED),
+                Some(t) if t >= 55 => (app.temp_unit.format_temp(t), p::YELLOW),
+                Some(t) => (app.temp_unit.format_temp(t), p::FG),
                 None => ("—".to_string(), p::DIM),
             },
             None => ("—".to_string(), p::DIM),
         };
-        let line = Line::from(vec![
+        let mut line_spans: Vec<Span> = vec![
             Span::raw(" "),
             Span::styled("\u{25cf}", Style::default().fg(dot_col)),
             Span::raw(" "),
             Span::styled(pad_right(&d.name, 11), Style::default().fg(p::FG)),
             Span::styled(pad_right(&d.model, 30), Style::default().fg(p::FG)),
-            Span::styled(
+        ];
+        if show_size {
+            line_spans.push(Span::styled(
                 pad_left(&fmt_size(d.size_bytes), 8),
                 Style::default().fg(p::DIM),
-            ),
-            Span::raw("  "),
-            Span::styled(
+            ));
+            line_spans.push(Span::raw("  "));
+        }
+        if show_free {
+            line_spans.push(Span::styled(
+                pad_left(&fmt_size(free_bytes), 8),
+                Style::default().fg(p::CYAN),
+            ));
+            line_spans.push(Span::raw("  "));
+        }
+        if show_used {
+            line_spans.push(Span::styled(
                 pad_left(&format!("{}%", used_pct), 4),
                 Style::default().fg(used_col),
-            ),
-            Span::raw("  "),
-            Span::styled(
+            ));
+            line_spans.push(Span::raw("  "));
+        }
+        if show_temp {
+            line_spans.push(Span::styled(
                 pad_left(&temp_text, 6),
                 Style::default().fg(temp_col),
-            ),
-            Span::raw("  "),
-            Span::styled(smart_text.to_string(), Style::default().fg(smart_col)),
-        ]);
+            ));
+            line_spans.push(Span::raw("  "));
+        }
+        if show_smart {
+            line_spans.push(Span::styled(smart_text.to_string(), Style::default().fg(smart_col)));
+        }
         f.render_widget(
-            Paragraph::new(line).style(Style::default().bg(p::BG)),
+            Paragraph::new(Line::from(line_spans))
+                .style(Style::default().bg(p::BG)),
             Rect {
                 x: inner.x + 1,
                 y: inner.y + 1 + i as u16,

--- a/src/tabs/overview.rs
+++ b/src/tabs/overview.rs
@@ -256,7 +256,7 @@ fn draw_devices_summary(f: &mut Frame, area: Rect, app: &App) {
     if inner.height < 2 {
         return;
     }
-    let header = "   DEVICE     MODEL                         SIZE     USED   SMART";
+    let header = "   DEVICE     MODEL                         SIZE     USED   TEMP  SMART";
     f.render_widget(
         Paragraph::new(Line::from(Span::styled(
             header.to_string(),
@@ -295,6 +295,18 @@ fn draw_devices_summary(f: &mut Frame, area: Rect, app: &App) {
             Some(false) => p::RED,
             None => p::DIM,
         };
+        // Temperature from the SMART collector (cached, polled per
+        // configured interval). Color-coded so a hot drive pops out
+        // without the user having to switch tabs.
+        let (temp_text, temp_col) = match app.smart.by_device.get(&d.name) {
+            Some(tick) => match tick.temperature_c {
+                Some(t) if t >= 70 => (format!("{}°C", t), p::RED),
+                Some(t) if t >= 55 => (format!("{}°C", t), p::YELLOW),
+                Some(t) => (format!("{}°C", t), p::FG),
+                None => ("—".to_string(), p::DIM),
+            },
+            None => ("—".to_string(), p::DIM),
+        };
         let line = Line::from(vec![
             Span::raw(" "),
             Span::styled("\u{25cf}", Style::default().fg(dot_col)),
@@ -309,6 +321,11 @@ fn draw_devices_summary(f: &mut Frame, area: Rect, app: &App) {
             Span::styled(
                 pad_left(&format!("{}%", used_pct), 4),
                 Style::default().fg(used_col),
+            ),
+            Span::raw("  "),
+            Span::styled(
+                pad_left(&temp_text, 6),
+                Style::default().fg(temp_col),
             ),
             Span::raw("  "),
             Span::styled(smart_text.to_string(), Style::default().fg(smart_col)),

--- a/src/tabs/smart.rs
+++ b/src/tabs/smart.rs
@@ -136,7 +136,7 @@ fn draw_attribute_panel(f: &mut Frame, area: Rect, app: &App) {
         .direction(Direction::Vertical)
         .constraints([Constraint::Length(10), Constraint::Min(3)])
         .split(split[1]);
-    draw_summary(f, body[0], tick, d);
+    draw_summary(f, body[0], tick, d, app.temp_unit);
     if !tick.ata_attrs.is_empty() {
         draw_ata_table(f, body[1], tick);
     }
@@ -193,10 +193,10 @@ fn draw_missing_smartctl_banner(f: &mut Frame, area: Rect, d: &DeviceTick) {
     );
 }
 
-fn draw_summary(f: &mut Frame, area: Rect, tick: &SmartTick, d: &DeviceTick) {
+fn draw_summary(f: &mut Frame, area: Rect, tick: &SmartTick, d: &DeviceTick, unit: crate::app::TempUnit) {
     let temp = tick
         .temperature_c
-        .map(|t| format!("{}°C", t))
+        .map(|t| unit.format_temp(t))
         .unwrap_or_else(|| "—".to_string());
     let temp_color = match tick.temperature_c {
         Some(t) if t >= 70 => p::RED,

--- a/src/tabs/smart.rs
+++ b/src/tabs/smart.rs
@@ -89,32 +89,56 @@ fn draw_attribute_panel(f: &mut Frame, area: Rect, app: &App) {
     let inner = block.inner(area);
     f.render_widget(block, area);
 
+    // Split: top row = root/sudo banner; rest = SMART content.
+    let split = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(2), Constraint::Min(4)])
+        .split(inner);
+    draw_root_banner(f, split[0]);
+
     let tick = app.smart.by_device.get(&d.name);
 
     if !app.smart.smartctl_available() {
-        draw_missing_smartctl_banner(f, inner, d);
+        draw_missing_smartctl_banner(f, split[1], d);
         return;
     }
 
     let Some(tick) = tick else {
+        let secs = app.smart.secs_until_next_refresh();
+        let countdown = if app.smart.smartctl_available() {
+            format!(
+                "  waiting for first SMART poll… next in ~{}s  (press r to refresh now)",
+                secs
+            )
+        } else {
+            "  waiting for smartctl probe…".to_string()
+        };
         f.render_widget(
             Paragraph::new(vec![
                 Line::from(""),
                 Line::from(Span::styled(
-                    "  waiting for first SMART poll (runs every 5 min)…",
+                    countdown,
                     Style::default().fg(p::DIM),
                 )),
             ])
             .style(Style::default().bg(p::BG)),
-            inner,
+            split[1],
         );
         return;
     };
 
-    if tick.ata_attrs.is_empty() {
-        draw_nvme_summary(f, inner, tick, d);
-    } else {
-        draw_ata_table(f, inner, tick);
+    // Layout the SMART body: top half always shows the headline summary
+    // (temp / hours / cycles / wear — what the Overview page's TEMP
+    // column also shows). Bottom half shows the per-protocol detail:
+    // NVMe gets nothing extra (the summary already lists every NVMe
+    // metric); ATA gets the full attribute table.
+    let body = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(10), Constraint::Min(3)])
+        .split(split[1]);
+    draw_summary(f, body[0], tick, d);
+    if !tick.ata_attrs.is_empty() {
+        draw_ata_table(f, body[1], tick);
     }
 }
 
@@ -169,7 +193,7 @@ fn draw_missing_smartctl_banner(f: &mut Frame, area: Rect, d: &DeviceTick) {
     );
 }
 
-fn draw_nvme_summary(f: &mut Frame, area: Rect, tick: &SmartTick, d: &DeviceTick) {
+fn draw_summary(f: &mut Frame, area: Rect, tick: &SmartTick, d: &DeviceTick) {
     let temp = tick
         .temperature_c
         .map(|t| format!("{}°C", t))
@@ -304,4 +328,54 @@ fn kv(key: &str, val: &str, val_color: ratatui::style::Color) -> Line<'static> {
         Span::styled(format!(" {:<16}", key), Style::default().fg(p::DIM)),
         Span::styled(val.to_string(), Style::default().fg(val_color)),
     ])
+}
+
+/// One-line banner at the top of the SMART panel. Tells the user whether
+/// they have full SMART access (root via sudo) or whether they need to
+/// relaunch with sudo to see temperature / wear / power-on hours.
+fn draw_root_banner(f: &mut Frame, area: Rect) {
+    if area.height < 1 || area.width < 10 {
+        return;
+    }
+    let line = if running_as_root() {
+        Line::from(vec![
+            Span::styled(" ✓ running as root — ", Style::default().fg(p::GREEN)),
+            Span::styled(
+                "full SMART data available",
+                Style::default().fg(p::DIM),
+            ),
+        ])
+    } else {
+        Line::from(vec![
+            Span::styled(" ⚠ ", Style::default().fg(p::YELLOW)),
+            Span::styled(
+                "for SMART statistics (temperature, wear, hours), launch with: ",
+                Style::default().fg(p::DIM),
+            ),
+            Span::styled(
+                "sudo diskwatch",
+                Style::default().fg(p::CYAN).add_modifier(Modifier::BOLD),
+            ),
+        ])
+    };
+    f.render_widget(
+        Paragraph::new(line).style(Style::default().bg(p::BG)),
+        Rect {
+            x: area.x,
+            y: area.y,
+            width: area.width,
+            height: 1,
+        },
+    );
+}
+
+#[cfg(unix)]
+fn running_as_root() -> bool {
+    // SAFETY: libc::geteuid is async-signal-safe and has no preconditions.
+    unsafe { libc::geteuid() == 0 }
+}
+
+#[cfg(not(unix))]
+fn running_as_root() -> bool {
+    false
 }

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -185,15 +185,14 @@ pub fn draw_footer(f: &mut Frame, area: Rect, extra: &[(char, &str)]) {
         Style::default().fg(p::DIM),
     ));
 
+    // Only bindings that are actually handled in `handle_key` are shown —
+    // diskwatch has no Snapshot/Diff/Profile/Rec/Filter features (those were
+    // inherited from the netwatch footer), and advertising them was issue #6
+    // ("dead shortcuts"). The SMART refresh/interval keys are appended via
+    // `extra`.
     let groups: &[&[(char, &str)]] = &[
         &[('p', "Pause"), (',', "Settings")],
-        &[
-            ('S', "Snapshot"),
-            ('D', "Diff"),
-            ('P', "Profile"),
-            ('R', "Rec"),
-        ],
-        &[('/', "Filter"), ('q', "Quit"), ('1', "Tab")],
+        &[('q', "Quit"), ('1', "Tab")],
         &[('?', "Help")],
     ];
     for (gi, g) in groups.iter().enumerate() {

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -173,6 +173,18 @@ pub fn draw_tab_bar(f: &mut Frame, area: Rect, active: TabId, insight_count: usi
 pub fn draw_footer(f: &mut Frame, area: Rect, extra: &[(char, &str)]) {
     let mut spans: Vec<Span> = Vec::new();
     spans.push(Span::raw(" "));
+
+    // Arrow-key navigation hint — always shown so users discover the
+    // per-tab picker (Devices, SMART, FS, Overview) on first launch.
+    spans.push(Span::styled(
+        "\u{2191}\u{2193}\u{2190}\u{2192}".to_string(),
+        Style::default().fg(p::CYAN).add_modifier(Modifier::BOLD),
+    ));
+    spans.push(Span::styled(
+        ":Nav ",
+        Style::default().fg(p::DIM),
+    ));
+
     let groups: &[&[(char, &str)]] = &[
         &[('p', "Pause"), (',', "Settings")],
         &[


### PR DESCRIPTION
## Summary

Fixes #6 ("dead shortcuts"), restores the SMART tab's per-device navigation that issue #6 also flagged, and adds live SMART polling control + an Overview-page temperature column so all of diskwatch's headline metrics stay visible without switching tabs.

## What changed

**1. Advertised keybindings now actually work.** The footer hint bar has long listed `,` `S` `D` `P` `R` `/` `?` Tab and arrow keys, but `handle_key` only bound `q` `p` `1`-`8` and `↑`/`↓`/`j`/`k` on Devices/FS. After this PR:

| Key | Behavior |
|---|---|
| `↑` `↓` `←` `→` `h` `j` `k` `l` | move per-tab selection on every tab that has a picker (Overview, Devices, SMART, FS); wrap at boundaries |
| `Home` `End` | jump to first/last |
| `PgUp` `PgDn` | jump by 5 |
| `Tab` `Shift+Tab` | cycle tabs (always) |
| `←` `→` on tabs with no picker (IO, Hot Files, Insights) | cycle tabs (no dead arrows) |
| `?` | centered help overlay listing every binding; any key dismisses |
| `r` | force immediate SMART refresh (bypasses cadence) |
| `+` `-` | nudge SMART poll cadence by 60s (5s floor, no ceiling) |
| `0` | reset cadence to upstream-conservative 5 min |
| `q` `Esc` | quit |

**2. SMART cadence is now configurable at runtime.** `SmartCollector` exposes `set_interval()`, `force_refresh()`, `current_interval()`, `secs_until_next_refresh()`, and a public `last_refresh_at` timestamp. Default still 5 min (drive-life safety — see the comment in `collect/smart.rs`). Footer shows the current value and the step size: `r:Refresh  +:5m  -:±60s`.

**3. SMART panel now shows headline metrics for ATA disks too.** Previously the panel rendered a clean summary header for NVMe (temperature, wear, available spare, power-on hours, power cycles, host read/write) but jumped straight to the raw attribute table for ATA — so `sda`/`sdb` appeared to have no SMART info even though temperature and hours were sitting in the table. Two changes:

  - The collector lifts `Power_On_Hours` (0x09), `Power_Cycle_Count` (0x0C), and `Reallocated_Sector_Ct` (0x05) from the ATA attribute table into the headline `SmartTick` fields, reading `raw.value` (the integer field) rather than `raw.string` (which ATA vendors suffix with units, e.g. `"33 (Min/Max 33/33)"`).
  - The panel always renders the summary header now, with the attribute table appended below for ATA disks.

  Result: SMART tab for `sda` now shows `34°C · 21916 hours (913 days) · 2008 cycles` plus the full attribute table; `sdb` shows `33°C · 18635 hours · 1564 cycles`.

**4. Overview page has a TEMP column** so every disk's temperature is visible without switching to the SMART tab. Color-coded: ≥70°C red, ≥55°C yellow. This also exposed a related parsing bug — smartctl's modern JSON emits a top-level `.temperature.current` field for both NVMe and ATA, but the collector only parsed the NVMe path. The collector now reads the top-level field as a fallback, so ATA drives populate `tick.temperature_c` directly.

**5. Root/sudo status banner on the SMART panel.** SMART requires read access to `/dev/sda`, `/dev/nvme0n1`, `/dev/nvme0` (NVMe admin), `/dev/sg*` — all root:disk 0660 or stricter. To make this obvious at a glance, the SMART panel now shows a one-line status banner at the top:
```
✓ running as root — full SMART data available           (when euid == 0)
⚠ for SMART statistics (temperature, wear, hours),       (otherwise)
  launch with: sudo diskwatch
```

**6. Footer hints updated.** Prepended `↑↓←→:Nav` so users discover per-tab navigation on first launch. Split the SMART extras into `r:Refresh  +:5m  -:±60s` so both interval keys and the step size are visible.

**7. Zero-area panic guard** (bonus, surfaced during testing). ratatui 0.29 panics on any draw into a Rect with width=0 or height=0 (`Buffer::cell_mut` bounds check at `buffer.rs:253`). Some terminals — notably Ghostty — report 0×0 size for the first frame after `EnterAlternateScreen`, causing the upstream binary to panic with `index outside of buffer` on launch in those terminals. `draw()` now skips rendering if the frame area is empty and waits one 50ms tick.

## Tested

Built and run on Fedora 44 / Bazzite with 5 disks (`nvme0n1`, `sda`, `nvme1n1`, `sdb`, `zram0`). Verified in tmux:

- All four arrow keys + `h/j/k/l` cycle devices on the SMART tab.
- Overview page shows temperature for every physical disk (`sda 34°C`, `sdb 33°C`, `nvme0n1 35°C`, `nvme1n1 40°C`).
- SMART tab shows the headline summary for ATA disks too.
- `+`/`-` nudge interval; `0` resets to default; `r` forces refresh.
- `?` opens the help overlay.
- Root banner shows correct status.

Builds cleanly with `cargo build --release` on rustc 1.97. The three pre-existing dead-code warnings (`filevault`, `rotational`, `first_byte_count`) are unchanged.

## Files touched

```
Cargo.lock           |   1 +
Cargo.toml           |   1 +
src/app.rs           | 315 ++++++++++++++++++++++++++++++++++++++++++++++++---
src/collect/smart.rs | 104 ++++++++++++++++-
src/tabs/overview.rs |  19 +++-
src/tabs/smart.rs    |  90 +++++++++++++--
src/ui/chrome.rs     |  12 ++
7 files changed, 512 insertions(+), 30 deletions(-)
```

New dependency: `libc = "0.2"` (for `geteuid()` only — the root detection).

## Notes for the maintainer

- I have NOT bumped the version in `Cargo.toml`. If you want this to ship as v0.1.3 the version line is the only thing left to flip.
- The 5-minute default for SMART cadence is intentional per the existing comment in `collect/smart.rs`; this PR makes it adjustable, not faster by default.
- `Volumes` tab keeps its own per-container/per-array picker state (managed inside `tabs/volumes.rs`); arrows there still work because Volumes was already handling `↑`/`↓` itself. Left/Right on Volumes cycles tabs (matches the no-dead-arrow rule).
